### PR TITLE
(Fixed) PureJavaComm http -> https

### DIFF
--- a/vcr4j-purejavacomm/pom.xml
+++ b/vcr4j-purejavacomm/pom.xml
@@ -36,7 +36,7 @@
     <repository>
         <id>sparetimelabs</id>
         <name>sparetimelabes</name>
-        <url>http://www.sparetimelabs.com/maven2/</url>
+        <url>https://www.sparetimelabs.com/maven2/</url>
     </repository>
     </repositories>
 </project>


### PR DESCRIPTION
-As suggested by @jeffday, amended "http" to "https" after it was discovered that Maven was blocking the repo.

**Following this change, vcr4j successfully built (Java 17)**